### PR TITLE
右键菜单路径空格Bug；增加右键菜单Icon；增加删除右键菜单

### DIFF
--- a/dependency/MainDlg.h
+++ b/dependency/MainDlg.h
@@ -80,6 +80,7 @@ protected:
     void OnMenuExit();
     void OnMenuAbout();
     void OnAddRightMenuContext();
+    void OnDelRightMenuContext();
     void OnMenuExpendAll();
     void OnMenuCollapseAll();
 

--- a/dependency/dependency.rc
+++ b/dependency/dependency.rc
@@ -44,6 +44,7 @@ BEGIN
     POPUP "帮助"
     BEGIN
         MENUITEM "添加到右键菜单",                     ID_ADD_DEFAULT_MENU
+        MENUITEM "删除右键菜单",                      ID_DEL_DEFAULT_MENU
         MENUITEM SEPARATOR
         MENUITEM "关于我们(&A)",                    ID_HELP_ABOUT
     END

--- a/dependency/resource.h
+++ b/dependency/resource.h
@@ -35,13 +35,15 @@
 #define ID_ADD_DEFAULT_MENU             32794
 #define ID_LISTITEM_COPY_ALL            32795
 #define ID_LISTCTRL_SELECTALL           32796
+#define ID_32798                        32798
+#define ID_DEL_DEFAULT_MENU             32799
 
 // Next default values for new objects
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        204
-#define _APS_NEXT_COMMAND_VALUE         32798
+#define _APS_NEXT_COMMAND_VALUE         32800
 #define _APS_NEXT_CONTROL_VALUE         1008
 #define _APS_NEXT_SYMED_VALUE           101
 #endif


### PR DESCRIPTION
1.  右键菜单文件路径有空格Bug；[Issue/9](https://github.com/JelinYao/dependency/issues/9)
2. 增加右键菜单图标Icon；
3. 增加取消删除右键菜单。

![2024-03-27 111805](https://github.com/JelinYao/dependency/assets/7234473/b82b0474-d34c-495c-bca7-f0a0ae3415db)
