### PR TITLE
修复菜单Bug和删除菜单

### DIFF
--- a/Debug/language/Chinese.xml
+++ b/Debug/language/Chinese.xml
@@ -16,4 +16,5 @@
     <string id="MsgDragMuiltipleFiles">不支持拖入多个文件</string>
     <string id="MsgCallFailed">调用失败，错误码：</string>
     <string id="AddToSystemMenu">添加到系统右键菜单</string>
+    <string id="DelToSystemMenu">删除系统右键菜单</string>
 </resources>

--- a/Debug/language/English.xml
+++ b/Debug/language/English.xml
@@ -16,4 +16,5 @@
     <string id="MsgDragMuiltipleFiles">Drag multiple files is not supported</string>
     <string id="MsgCallFailed">execute failed，error code: </string>
     <string id="AddToSystemMenu">add to system menu</string>
+    <string id="DelToSystemMenu">delete system menu</string>
 </resources>

--- a/Release/language/Chinese.xml
+++ b/Release/language/Chinese.xml
@@ -16,4 +16,5 @@
     <string id="MsgDragMuiltipleFiles">不支持拖入多个文件</string>
     <string id="MsgCallFailed">调用失败，错误码：</string>
     <string id="AddToSystemMenu">添加到系统右键菜单</string>
+    <string id="DelToSystemMenu">删除系统右键菜单</string>
 </resources>

--- a/Release/language/English.xml
+++ b/Release/language/English.xml
@@ -16,4 +16,5 @@
     <string id="MsgDragMuiltipleFiles">Drag multiple files is not supported</string>
     <string id="MsgCallFailed">execute failed，error code: </string>
     <string id="AddToSystemMenu">add to system menu</string>
+    <string id="DelToSystemMenu">delete system menu</string>
 </resources>

--- a/dependency/Language.h
+++ b/dependency/Language.h
@@ -18,6 +18,7 @@ namespace language {
     static CONSTEXPR char* kCollapseAll = "CollapseAll";
     static CONSTEXPR char* kAbout = "About";
     static CONSTEXPR char* kAddToSystemMenu = "AddToSystemMenu";
+    static CONSTEXPR char* kDelToSystemMenu = "DelToSystemMenu";
     static CONSTEXPR char* kOpenInvalidFile = "OpenInvalidFile";
     static CONSTEXPR char* kTipTitle = "TipTitle";
     static CONSTEXPR char* kErrorTitle = "ErrorTitle";

--- a/dependency/MainDlg.h
+++ b/dependency/MainDlg.h
@@ -80,6 +80,7 @@ protected:
     void OnMenuExit();
     void OnMenuAbout();
     void OnAddRightMenuContext();
+    void OnDelRightMenuContext();
     void OnMenuExpendAll();
     void OnMenuCollapseAll();
 

--- a/dependency/MenuDefine.h
+++ b/dependency/MenuDefine.h
@@ -25,6 +25,7 @@ static CONSTEXPR int kViewMenuCount = _countof(kViewMenuList);
 // help menu
 static CONSTEXPR char* kHelpMenuList[] = {
     language::kAddToSystemMenu,
+    language::kDelToSystemMenu,
     nullptr,
     language::kAbout,
 };

--- a/dependency/dependency.rc
+++ b/dependency/dependency.rc
@@ -44,6 +44,7 @@ BEGIN
     POPUP "帮助"
     BEGIN
         MENUITEM "添加到右键菜单",                     ID_ADD_DEFAULT_MENU
+        MENUITEM "删除右键菜单",                      ID_DEL_DEFAULT_MENU
         MENUITEM SEPARATOR
         MENUITEM "关于我们(&A)",                    ID_HELP_ABOUT
     END

--- a/dependency/resource.h
+++ b/dependency/resource.h
@@ -35,13 +35,15 @@
 #define ID_ADD_DEFAULT_MENU             32794
 #define ID_LISTITEM_COPY_ALL            32795
 #define ID_LISTCTRL_SELECTALL           32796
+#define ID_32798                        32798
+#define ID_DEL_DEFAULT_MENU             32799
 
 // Next default values for new objects
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        204
-#define _APS_NEXT_COMMAND_VALUE         32798
+#define _APS_NEXT_COMMAND_VALUE         32800
 #define _APS_NEXT_CONTROL_VALUE         1008
 #define _APS_NEXT_SYMED_VALUE           101
 #endif


### PR DESCRIPTION
1. 修复右键菜单路径空格Bug；[Issue/9](https://github.com/JelinYao/dependency/issues/9)

2. 增加右键菜单图标；

3. 增加删除右键菜单。

![317114945-b82b0474-d34c-495c-bca7-f0a0ae3415db](https://github.com/JelinYao/dependency/assets/7234473/a336988d-c951-494a-a8a8-8a2820b382d1)
